### PR TITLE
Implement Full Scan Least Request load balancing algorithm

### DIFF
--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -150,6 +150,11 @@ message Cluster {
     // Refer to the :ref:`Maglev load balancing policy<arch_overview_load_balancing_types_maglev>`
     // for an explanation.
     MAGLEV = 5;
+
+    // Refer to the :ref:`least request load balancing
+    // policy<arch_overview_load_balancing_types_least_request>`
+    // for an explanation.
+    LEAST_REQUEST_FULL = 6;
   }
   // The :ref:`load balancer type <arch_overview_load_balancing_types>` to use
   // when picking a host in the cluster.

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -151,9 +151,6 @@ message Cluster {
     // for an explanation.
     MAGLEV = 5;
 
-    // Refer to the :ref:`least request load balancing
-    // policy<arch_overview_load_balancing_types_least_request>`
-    // for an explanation.
     LEAST_REQUEST_FULL = 6;
   }
   // The :ref:`load balancer type <arch_overview_load_balancing_types>` to use

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -116,7 +116,8 @@ elif [[ "$1" == "bazel.dev" ]]; then
     "${ENVOY_CI_DIR}"/bazel-bin/source/exe/envoy-static \
     "${ENVOY_DELIVERY_DIR}"/envoy-fastbuild
   echo "Building and testing..."
-  bazel --batch test ${BAZEL_TEST_OPTIONS} -c fastbuild //test/...
+  echo "Skipping tests"
+  # bazel --batch test ${BAZEL_TEST_OPTIONS} -c fastbuild //test/...
   exit 0
 elif [[ "$1" == "bazel.ipv6_tests" ]]; then
   # This is around until Circle supports IPv6. We try to run a limited set of IPv6 tests as fast

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -116,8 +116,7 @@ elif [[ "$1" == "bazel.dev" ]]; then
     "${ENVOY_CI_DIR}"/bazel-bin/source/exe/envoy-static \
     "${ENVOY_DELIVERY_DIR}"/envoy-fastbuild
   echo "Building and testing..."
-  echo "Skipping tests"
-  # bazel --batch test ${BAZEL_TEST_OPTIONS} -c fastbuild //test/...
+  bazel --batch test ${BAZEL_TEST_OPTIONS} -c fastbuild //test/...
   exit 0
 elif [[ "$1" == "bazel.ipv6_tests" ]]; then
   # This is around until Circle supports IPv6. We try to run a limited set of IPv6 tests as fast

--- a/include/envoy/upstream/load_balancer_type.h
+++ b/include/envoy/upstream/load_balancer_type.h
@@ -14,7 +14,15 @@ namespace Upstream {
 /**
  * Type of load balancing to perform.
  */
-enum class LoadBalancerType { RoundRobin, LeastRequest, LeastRequestFull, Random, RingHash, OriginalDst, Maglev };
+enum class LoadBalancerType {
+  RoundRobin,
+  LeastRequest,
+  LeastRequestFull,
+  Random,
+  RingHash,
+  OriginalDst,
+  Maglev
+};
 
 /**
  * Load Balancer subset configuration.

--- a/include/envoy/upstream/load_balancer_type.h
+++ b/include/envoy/upstream/load_balancer_type.h
@@ -14,7 +14,7 @@ namespace Upstream {
 /**
  * Type of load balancing to perform.
  */
-enum class LoadBalancerType { RoundRobin, LeastRequest, Random, RingHash, OriginalDst, Maglev };
+enum class LoadBalancerType { RoundRobin, LeastRequest, LeastRequestFull, Random, RingHash, OriginalDst, Maglev };
 
 /**
  * Load Balancer subset configuration.

--- a/source/common/config/cds_json.cc
+++ b/source/common/config/cds_json.cc
@@ -160,6 +160,8 @@ void CdsJson::translateCluster(const Json::Object& json_cluster,
     cluster.set_lb_policy(envoy::api::v2::Cluster::ROUND_ROBIN);
   } else if (lb_type == "least_request") {
     cluster.set_lb_policy(envoy::api::v2::Cluster::LEAST_REQUEST);
+  } else if (lb_type == "least_request_full") {
+    cluster.set_lb_policy(envoy::api::v2::Cluster::LEAST_REQUEST_FULL);
   } else if (lb_type == "random") {
     cluster.set_lb_policy(envoy::api::v2::Cluster::RANDOM);
   } else if (lb_type == "original_dst_lb") {

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -1469,7 +1469,7 @@ const std::string Json::Schema::CLUSTER_SCHEMA(R"EOF(
       },
       "lb_type" : {
         "type" : "string",
-        "enum" : ["round_robin", "least_request", "random", "ring_hash", "original_dst_lb"]
+        "enum" : ["round_robin", "least_request", "least_request_full", "random", "ring_hash", "original_dst_lb"]
       },
       "ring_hash_lb_config" : {
         "type" : "object",

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1044,6 +1044,13 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::ClusterEntry(
                                              parent.parent_.random_, cluster->lbConfig()));
       break;
     }
+    case LoadBalancerType::LeastRequestFull: {
+      ASSERT(lb_factory_ == nullptr);
+      lb_.reset(new LeastRequestFullLoadBalancer(priority_set_, parent_.local_priority_set_,
+                                                 cluster->stats(), parent.parent_.runtime_,
+                                                 parent.parent_.random_, cluster->lbConfig()));
+      break;
+    }
     case LoadBalancerType::Random: {
       ASSERT(lb_factory_ == nullptr);
       lb_.reset(new RandomLoadBalancer(priority_set_, parent_.local_priority_set_, cluster->stats(),

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -1,5 +1,6 @@
 #include "common/upstream/load_balancer_impl.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -8,6 +9,7 @@
 #include "envoy/upstream/upstream.h"
 
 #include "common/common/assert.h"
+#include "common/common/logger.h"
 #include "common/protobuf/utility.h"
 
 namespace Envoy {
@@ -511,6 +513,14 @@ HostConstSharedPtr LeastRequestLoadBalancer::unweightedHostPick(const HostVector
   } else {
     return host2;
   }
+}
+
+HostConstSharedPtr LeastRequestFullLoadBalancer::unweightedHostPick(const HostVector& hosts_to_use,
+                                                                    const HostsSource&) {
+  return *std::min_element(
+    hosts_to_use.begin(),
+    hosts_to_use.end(),
+    [](const HostSharedPtr& a, const HostSharedPtr& b) { return a->stats().rq_active_.value() < b->stats().rq_active_.value(); });
 }
 
 HostConstSharedPtr RandomLoadBalancer::chooseHost(LoadBalancerContext*) {

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -517,10 +517,10 @@ HostConstSharedPtr LeastRequestLoadBalancer::unweightedHostPick(const HostVector
 
 HostConstSharedPtr LeastRequestFullLoadBalancer::unweightedHostPick(const HostVector& hosts_to_use,
                                                                     const HostsSource&) {
-  return *std::min_element(
-    hosts_to_use.begin(),
-    hosts_to_use.end(),
-    [](const HostSharedPtr& a, const HostSharedPtr& b) { return a->stats().rq_active_.value() < b->stats().rq_active_.value(); });
+  return *std::min_element(hosts_to_use.begin(), hosts_to_use.end(),
+                           [](const HostSharedPtr& a, const HostSharedPtr& b) {
+                             return a->stats().rq_active_.value() < b->stats().rq_active_.value();
+                           });
 }
 
 HostConstSharedPtr RandomLoadBalancer::chooseHost(LoadBalancerContext*) {

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -339,6 +339,29 @@ private:
 };
 
 /**
+ * Least Request Full Scan load balancer.
+ */
+class LeastRequestFullLoadBalancer : public EdfLoadBalancerBase {
+public:
+  LeastRequestFullLoadBalancer(const PrioritySet& priority_set, const PrioritySet* local_priority_set,
+                           ClusterStats& stats, Runtime::Loader& runtime,
+                           Runtime::RandomGenerator& random,
+                           const envoy::api::v2::Cluster::CommonLbConfig& common_config)
+      : EdfLoadBalancerBase(priority_set, local_priority_set, stats, runtime, random,
+                            common_config) {
+    initialize();
+  }
+
+private:
+  void refreshHostSource(const HostsSource&) override {}
+  double hostWeight(const Host& host) override {
+    return static_cast<double>(host.weight()) / (host.stats().rq_active_.value() + 1);
+  }
+  HostConstSharedPtr unweightedHostPick(const HostVector& hosts_to_use,
+                                        const HostsSource& source) override;
+};
+
+/**
  * Random load balancer that picks a random host out of all hosts.
  */
 class RandomLoadBalancer : public LoadBalancer, ZoneAwareLoadBalancerBase {

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -343,10 +343,10 @@ private:
  */
 class LeastRequestFullLoadBalancer : public EdfLoadBalancerBase {
 public:
-  LeastRequestFullLoadBalancer(const PrioritySet& priority_set, const PrioritySet* local_priority_set,
-                           ClusterStats& stats, Runtime::Loader& runtime,
-                           Runtime::RandomGenerator& random,
-                           const envoy::api::v2::Cluster::CommonLbConfig& common_config)
+  LeastRequestFullLoadBalancer(const PrioritySet& priority_set,
+                               const PrioritySet* local_priority_set, ClusterStats& stats,
+                               Runtime::Loader& runtime, Runtime::RandomGenerator& random,
+                               const envoy::api::v2::Cluster::CommonLbConfig& common_config)
       : EdfLoadBalancerBase(priority_set, local_priority_set, stats, runtime, random,
                             common_config) {
     initialize();

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -435,6 +435,12 @@ SubsetLoadBalancer::PrioritySubsetImpl::PrioritySubsetImpl(const SubsetLoadBalan
                                            subset_lb.common_config_));
     break;
 
+  case LoadBalancerType::LeastRequestFull:
+    lb_.reset(new LeastRequestFullLoadBalancer(*this, subset_lb.original_local_priority_set_,
+                                               subset_lb.stats_, subset_lb.runtime_, subset_lb.random_,
+                                               subset_lb.common_config_));
+    break;
+
   case LoadBalancerType::Random:
     lb_.reset(new RandomLoadBalancer(*this, subset_lb.original_local_priority_set_,
                                      subset_lb.stats_, subset_lb.runtime_, subset_lb.random_,

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -437,8 +437,8 @@ SubsetLoadBalancer::PrioritySubsetImpl::PrioritySubsetImpl(const SubsetLoadBalan
 
   case LoadBalancerType::LeastRequestFull:
     lb_.reset(new LeastRequestFullLoadBalancer(*this, subset_lb.original_local_priority_set_,
-                                               subset_lb.stats_, subset_lb.runtime_, subset_lb.random_,
-                                               subset_lb.common_config_));
+                                               subset_lb.stats_, subset_lb.runtime_,
+                                               subset_lb.random_, subset_lb.common_config_));
     break;
 
   case LoadBalancerType::Random:

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -325,6 +325,9 @@ ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
   case envoy::api::v2::Cluster::LEAST_REQUEST:
     lb_type_ = LoadBalancerType::LeastRequest;
     break;
+  case envoy::api::v2::Cluster::LEAST_REQUEST_FULL:
+    lb_type_ = LoadBalancerType::LeastRequestFull;
+    break;
   case envoy::api::v2::Cluster::RANDOM:
     lb_type_ = LoadBalancerType::Random;
     break;


### PR DESCRIPTION
A simple, naive implementation of a **full scan** version of the `LEAST_REQUEST` load balancing algorithm. It can be used by setting the load balancer type to `LEAST_REQUEST_FULL` instead of `LEAST_REQUEST` (which does P2C, and not a full scan).